### PR TITLE
Added functionality to scrap all pages in a season

### DIFF
--- a/leagues/soccer/08-europe-champions-league.json
+++ b/leagues/soccer/08-europe-champions-league.json
@@ -1,0 +1,22 @@
+{
+  "league": "Champions League",
+  "area": "Europe",
+  "urls": [
+    "https://www.oddsportal.com/soccer/europe/champions-league-2003-2004/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2004-2005/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2005-2006/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2006-2007/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2007-2008/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2008-2009/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2009-2010/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2010-2011/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2011-2012/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2012-2013/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2013-2014/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2014-2015/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2015-2016/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2016-2017/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league-2017-2018/results/",
+    "https://www.oddsportal.com/soccer/europe/champions-league/results/"
+  ]
+}


### PR DESCRIPTION
Hi, I found this project while searching for the results from the champions league. Found it very useful but the problem is that the scrapper works only for the first page of the table and since each page contains only 50 elements you lost a lot of elements.  I added a simple while for each season incrementing a page number until an empty table is retrieved.

Also added a json file for the champions league. 